### PR TITLE
Fix/ember paper

### DIFF
--- a/addon/services/paper-toaster.js
+++ b/addon/services/paper-toaster.js
@@ -3,7 +3,6 @@ import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 import { A } from '@ember/array';
 import Service from '@ember/service';
-import { tryInvoke } from '@ember/utils';
 import EObject from '@ember/object';
 import config from 'ember-get-config';
 

--- a/addon/templates/components/paper-dialog.hbs
+++ b/addon/templates/components/paper-dialog.hbs
@@ -1,4 +1,4 @@
-{{#-in-element destinationEl}}
+{{#maybe-in-element destinationEl}}
   {{paper-backdrop
     locked-open=isLockedOpen
     opaque=opaque
@@ -17,4 +17,4 @@
       {{yield}}
     {{/paper-dialog-inner}}
   {{/paper-dialog-container}}
-{{/-in-element}}
+{{/maybe-in-element}}

--- a/addon/templates/components/paper-toast.hbs
+++ b/addon/templates/components/paper-toast.hbs
@@ -1,7 +1,7 @@
-{{#-in-element destinationEl}}
+{{#maybe-in-element destinationEl}}
   {{#paper-toast-inner swipe=swipeAction swipeToClose=swipeToClose onClose=onClose top=top left=left capsule=capsule class=class}}
     {{yield (hash
       text=(component "paper-toast-text")
     )}}
   {{/paper-toast-inner}}
-{{/-in-element}}
+{{/maybe-in-element}}

--- a/addon/templates/components/paper-tooltip.hbs
+++ b/addon/templates/components/paper-tooltip.hbs
@@ -1,9 +1,9 @@
 {{#if renderTooltip}}
-  {{#-in-element destinationEl}}
+  {{#maybe-in-element destinationEl}}
     <div class="md-panel-outer-wrapper md-panel-is-showing" style={{containerStyle}}>
       {{#paper-tooltip-inner class=class position=position anchorElement=anchorElement hide=hideTooltip}}
         {{yield}}
       {{/paper-tooltip-inner}}
     </div>
-  {{/-in-element}}
+  {{/maybe-in-element}}
 {{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-paper",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-paper",
   "description": "The Ember approach to Material Design.",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.33",
   "scripts": {
     "build": "ember build --environment=production",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
Reverting to ember-paper 1.0.0-beta.33 in package.json does NOT fix PaperMenuContent.animateOut errors.