### PR TITLE
fix: Updated validation-mixins

### DIFF
--- a/addon/mixins/validation-mixin.js
+++ b/addon/mixins/validation-mixin.js
@@ -58,12 +58,16 @@ function buildComputedValidationMessages(property, validations = [], customValid
       }
     });
 
-    // error messages array
+    // error messages array and string
     let errors = this.get('errors') || [];
-    assert('`errors` must be an array', isArray(errors));
-    messages.pushObjects(errors.map((e) => {
-      return get(e, 'message') ? e : { message: e };
-    }));
+    assert('`errors` must be an array or string', isArray(errors) || typeof errors === 'string' || errors instanceof String);
+    if (isArray(errors)) {
+      messages.pushObjects(errors.map((e) => {
+        return get(e, 'message') ? e : { message: e };
+      }));
+    } else if (typeof errors === 'string' || errors instanceof String) {
+      messages.pushObject({ message: errors });
+    }
 
     return messages;
   });


### PR DESCRIPTION
ember-paper v32 with feat: allow errors to be a string.
